### PR TITLE
URW-169 Update activities page

### DIFF
--- a/activities.php
+++ b/activities.php
@@ -28,8 +28,8 @@ head('Activities', true);
 			 	<div class="cell-lg-12">
 					
 			 	  <h4>UNT Robotics works to help the students of UNT</h4>
-			 	  <p>Our main goal is hosting meetings that educate our members and give them opportunities. To meet that goal, we’ve brought out several companies across disciplines such as L3, RoboKind, and StandardUser CyberSecurity. These companies were chosen because they fit the major demographics of our organization: Mechanical, Biomedical, and computer science/engineering. </p>
-			 	  <p>In addition to these companies coming out, we also host workshops that teach how robotics work. They, like most of our general meetings, are open to all. These workshops taught our members from the basics of electronics all the way up to using Bluetooth communication to control robotics. </p>
+			 	  <p>Our main goal is hosting meetings that educate our members and give them opportunities. To meet that goal, we’ve brought out several companies across various disciplines such as L3, RoboKind, and StandardUser CyberSecurity. Each company is selected because they fit at least one of the major demographics of our organization: Mechanical, Biomedical, and computer science/engineering. </p>
+			 	  <p>In addition to the STEM companies' seminars, we also host workshops that teach how robotics work. They, like most of our general meetings, are open to all and teach our members from the basics of electronics all the way up to using Bluetooth communication to control robots. </p>
 					
 			 	  <h4>UNT Robotics works with other organizations</h4>
 			 	  <p>UNT Robotics has collaborated with the Society of Automotive Engineers where we are building their dash and assisting with their wiring harness. </p>
@@ -38,10 +38,10 @@ head('Activities', true);
 			 	  <p>UNT Robotics worked with Kappa Delta Pi, an education honor society, to host a STEM education workshop for future teachers where we discussed the Engineering portion of STEM. We taught programming using Scratch, gear ratios using LEGO, and computer structure and design using skits. </p>
 					
 				  <h4>Inter-collegiate Competitions</h4>
-			 	  <p>Our collegiate team just came back from a competition in Louisiana where we competed in the IEEE R5 Autonomous Rover competition where we were commended for our mechanical engineering prowess. </p>
+			 	  <p>In Louisiana, we competed in the IEEE R5 Autonomous Rover competition where we were commended for our mechanical engineering prowess. </p>
 				
 				  <h4>Botathon</h4>
-			 	  <p>UNT Robotics also hosts a 12 hour Hackathon for robotics. It is on April 27th. We expect around 60 people to attend. It is intended to be an intro to robotics for anyone who wants to attend.</p>
+			 	  <p>UNT Robotics also hosts a 12 hour Hackathon for robotics in the early spring every year. Students get to design, build, and program a robot to fulfill the competition theme and objectives. For information about the next upcoming Botathon, visit <a href="botathon/index">the Botathon page</a> </p>
                 	
 				</div>
 			</div>

--- a/activities.php
+++ b/activities.php
@@ -41,7 +41,7 @@ head('Activities', true);
 			 	  <p>In Louisiana, we competed in the IEEE R5 Autonomous Rover competition where we were commended for our mechanical engineering prowess. </p>
 				
 				  <h4>Botathon</h4>
-			 	  <p>UNT Robotics also hosts a 12 hour Hackathon for robotics in the early spring every year. Students get to design, build, and program a robot to fulfill the competition theme and objectives. For information about the next upcoming Botathon, visit <a href="botathon/index">the Botathon page</a> </p>
+			 	  <p>UNT Robotics also hosts a 12 hour Hackathon for robotics in the early spring every year. As an introduction to robotics, students get to design, build, and program a robot to fulfill the competition theme and objectives. For information about the next upcoming Botathon, visit <a href="botathon/index">the Botathon page</a> </p>
                 	
 				</div>
 			</div>

--- a/activities.php
+++ b/activities.php
@@ -39,7 +39,7 @@ head('Activities', true);
 					
 				  <h4>Inter-collegiate Competitions</h4>
 			 	  <p>In Louisiana, we competed in the IEEE R5 Autonomous Rover competition where we were commended for our mechanical engineering prowess. </p>
-				
+				  <p>UNT Robotics competes in the NASA University Student Launch Initiative, where teams are tasked with designing a rocket and its payload to fulfill requirements and themes set by NASA for the year's competition. Whether we <a href="https://youtu.be/DRm8GA1gIDE?t=43">successfully launch a rocket</a>, or <a href="https://youtu.be/o7km5D4jRNI?t=144">spectactularly fail</a>, our team members learn valuable skills in engineering and teamwork. </p>
 				  <h4>Botathon</h4>
 			 	  <p>UNT Robotics also hosts a 12 hour Hackathon for robotics in the early spring every year. As an introduction to robotics, students get to design, build, and program a robot to fulfill the competition theme and objectives. For information about the next upcoming Botathon, visit <a href="botathon/index">the Botathon page</a> </p>
                 	


### PR DESCRIPTION
Information was either
a) poorly worded (e.g. "companies coming out", "these companies" [when the wording of "such as" implies that there are more, but usage of "these" sounds like we are only referring to the 3 example comapnies given]; etc.)
b) not up-to-date (e.g. "Our collegiate team just came back"; botathon being on April 29)

Also adjusted the Botathon section. This way it sells better than "an intro to robotics". And there's now an href to the botathon page (I know it's in the nav bar, but I still say we should do that so they don't have to look for the page at all.)