### PR TITLE
URW-194 Fix Twilio call status not logging properly

### DIFF
--- a/twilio/find-first/find-first-available.php
+++ b/twilio/find-first/find-first-available.php
@@ -76,7 +76,7 @@ function call_status($sid) {
 
         $data = json_decode($result);
 	
-		error_log("OUTGOING CALL STATUS: " . $data);
+		error_log("OUTGOING CALL STATUS: " . $data->status);
 	
 		return $data->status;
 }


### PR DESCRIPTION
`get-first-available.php` was throwing a conversion error in the `error_log` on line 79:
```
PHP Recoverable fatal error:  Object of class stdClass could not be converted to string in /var/www/untrobotics/twilio/find-first/find-first-available.php on line 7
```
This is to fix it by logging the object property instead of the object itself.

...

I just realized the branch name is misleading