### PR TITLE
URW-197 Fix /merch/product page breadcrumbs

### DIFF
--- a/merch/product.php
+++ b/merch/product.php
@@ -63,10 +63,10 @@ if ($product_can_be_handled) {
 	$back_file = $selected_variant->get_file_by_type(PrintfulVariantFilesTypes::BACK);
 	
 	head("Buy {$product->get_name()}", true);
-    $category_name = strtolower(preg_replace('@^.*\(([^()]+)\)$@i', '$1', $product->get_name()));
-    if($category_name !== 'gear' && $category_name[-1]!=='s'){
-        $category_name .= 's';
-    }
+	$category_name = strtolower(preg_replace('@^.*\(([^()]+)\)$@i', '$1', $product->get_name()));
+	if($category_name !== 'gear' && $category_name[-1]!=='s'){
+	$category_name .= 's';
+	}
 
 } else {
 	head("Invalid Product", true);
@@ -103,8 +103,8 @@ function get_variant_variant($variant_name) {
 		width: 100%;
 	}
 	.merch-section h6 {
-	    border-bottom: 1px solid #a7a7a7;
-	    margin-bottom: 5px;
+		border-bottom: 1px solid #a7a7a7;
+		margin-bottom: 5px;
 	}
 	.product-price {
 		color: red;
@@ -130,9 +130,9 @@ function get_variant_variant($variant_name) {
 	}
 	.variant-btn-container {
 		display: block;
-	    height: 50px;
-	    width: 100px;
-	    position: relative;
+		height: 50px;
+		width: 100px;
+		position: relative;
 	}
 	.variant-btn {
 		border: 1px solid #d8d8d8;
@@ -164,9 +164,9 @@ function get_variant_variant($variant_name) {
 			<ul class="list-breadcrumb">
 			  <li><a href="/">Home</a></li>
 			  <li><a href="/merch">Merch</a></li>
-                <?php if ($product_can_be_handled) { ?>
+	<?php if ($product_can_be_handled) { ?>
 			  <li><a href="/merch/<?php echo $category_name; ?>"><?php echo $category_name; ?></a></li>
-                <?php } ?>
+	<?php } ?>
 			  <li>Product</li>
 			</ul>
 		  </div>
@@ -325,7 +325,7 @@ function get_variant_variant($variant_name) {
 									//echo $button['btn'];
 									$button = $payment_button->get_button();
 									if ($button->error === false) {
-									    echo "button success";
+										echo "button success";
 										echo $payment_button->get_button()->button;
 									} else {
 										// TODO: Alert

--- a/merch/product.php
+++ b/merch/product.php
@@ -63,6 +63,11 @@ if ($product_can_be_handled) {
 	$back_file = $selected_variant->get_file_by_type(PrintfulVariantFilesTypes::BACK);
 	
 	head("Buy {$product->get_name()}", true);
+    $category_name = strtolower(preg_replace('@^.*\(([^()]+)\)$@i', '$1', $product->get_name()));
+    if($category_name !== 'gear' && $category_name[-1]!=='s'){
+        $category_name .= 's';
+    }
+
 } else {
 	head("Invalid Product", true);
 }
@@ -160,7 +165,7 @@ function get_variant_variant($variant_name) {
 			  <li><a href="/">Home</a></li>
 			  <li><a href="/merch">Merch</a></li>
                 <?php if ($product_can_be_handled) { ?>
-			  <li><a href="/merch/<?php echo strtolower($catalog_product->get_type_name()).'s'; ?>"><?php echo $catalog_product->get_type_name(); ?>s</a></li>
+			  <li><a href="/merch/<?php echo $category_name; ?>"><?php echo $category_name; ?></a></li>
                 <?php } ?>
 			  <li>Product</li>
 			</ul>


### PR DESCRIPTION
Previous breadcrumbs used the Printful-defined product type. For certain products (especially those in the gear section), this category is not related to any pages on the website.

Example:
![image](https://github.com/user-attachments/assets/d0c83e00-55d3-43e1-9578-97eb19fda80a)

This change uses the product name instead, since we're the ones that set it.

Lines 67-69 check to add an 's' at the end if the category isn't gear and not already plural because some search terms are already plural (i.e., trousers and gear). So, the only category that needs an "s" added to the end is `Hat`. I'm assuming that future product category pages will have a plural name but the search term will be singular too. E.g., if we have a watch category, the page would be `/merch/watches` and the search term would be `(Watch)`.