### PR TITLE
URW 191 Componentize member cards

### DIFF
--- a/about/our-alumni.php
+++ b/about/our-alumni.php
@@ -1,14 +1,79 @@
 <?php
 require('../template/top.php');
+require('../template/functions/card.php');
 head('Our Alumni', true);
+$members = array();
+$members[] = [
+    'name'=>'Nick Tindle',
+    'title'=>'1st President',
+    'description'=>"I am a Computer Engineering Student, The first president, and still an active member of the group",
+    'picture_uri'=>'/images/bio-pics/nick-tindle.jpg',
+//    'email'=>'',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+$members[] = [
+    'name'=>'Juan Ruiz',
+    'title'=>'2nd President',
+    'description'=>"I am a Computer Engineering Student, I.T. Support Technician, and Undergrad Research Assistant at The University of North Texas. I am an active member of The Alpha Tau Omega Fraternity, Society of Hispanic Professional Engineers, Engineers without Borders, IEEE, and National Society of Professional Engineers. I have also interned at NASA, U.S. Department of Energy, and iOLAP. My focus is Embedded Systems but I have a strong passion for robotics, automation, machine learning, and artificial intelligence.",
+    'picture_uri'=>'/images/bio-pics/juan-ruiz.jpg',
+//    'email'=>'',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+$members[] = [
+    'name'=>'Katie Lee',
+    'title'=>'Former Secretary',
+    'description'=>"I’m a transfer student from UH. I’m studying Computer Engineering because I want to be on the front of the newest technology development, and I’m the secretary for UNT Robotics.",
+    'picture_uri'=>'/images/bio-pics/katie-lee.jpg',
+//    'email'=>'',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+$members[] = [
+    'name'=>'Michelle Rosal Vargas',
+    'title'=>'Former Event Coordinator',
+    'description'=>"Mechanical Engineer | Event Coordinator at UNT Robotics",
+    'picture_uri'=>'/images/bio-pics/michelle-vargas.jpg',
+//    'email'=>'',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+$members[] = [
+    'name'=>'Andrew Jarrett',
+    'title'=>'Former Public Relations',
+    'description'=>"Mechanical Engineer | Public Relations at UNT Robotics",
+    'picture_uri'=>'/images/bio-pics/andrew-jarrett.jpg',
+//    'email'=>'',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+$members[] = [
+    'name'=>'Nicole Kohm',
+    'title'=>'Former Project Manager',
+    'description'=>"I am an adaptive problem-solver with a lifetime of scientific passion. I enjoy applying what I learn to make new ideas and possibilities come to fruition. I have a strong track record of careful attention to detail and thinking outside the box. I frequently invent new technologies and methods to quickly solve multidisciplinary problems.",
+    'picture_uri'=>'/images/bio-pics/nicole-kohm.jpg',
+//    'email'=>'',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+$members[] = [
+    'name'=>'Jesse Sullivan',
+    'title'=>'Former Aerospace Division Lead',
+    'description'=>"Jesse is a senior mechanical engineering student interested in all things that fly and go fast. He has 4 years of experience in amateur high-power rocketry and currently holds an L1 certification with the National Association of Rocketry. He founded the Aerospace Division with UNT Robotics in order to foster interest in the hobby and provide a learning experience for anyone to become a part of.",
+    'picture_uri'=>'/images/bio-pics/jesse-sullivan.jpg',
+//    'email'=>'',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
 ?>
-    <style>
-        .bio-area {
-            border-top: 2px solid #ececec;
-            margin-top: 10px;
-            padding-top: 10px;
-        }
-    </style>
     <main class="page-content">
         <!-- Classic Breadcrumbs-->
         <section class="breadcrumb-classic">
@@ -33,101 +98,11 @@ head('Our Alumni', true);
                         <h6>These people are the ones responsible for building our organisation and getting us to where we are today.</h6>
                     </div>
                 </div>
-                <!-- 1st President -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/nick-tindle.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#"> Nick Tindle</a><span class="small text-silver-chalice">1st President</span></h6>
-                                <p>I am a Computer Engineering Student, The first president, and still an active member of the group</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- 2nd President -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/juan-ruiz.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#"> Juan Ruiz</a><span class="small text-silver-chalice">2nd President</span></h6>
-                                <p>I am a Computer Engineering Student, I.T. Support Technician, and Undergrad Research Assistant at The University of North Texas. I am an active member of The Alpha Tau Omega Fraternity, Society of Hispanic Professional Engineers, Engineers without Borders, IEEE, and National Society of Professional Engineers. I have also interned at NASA, U.S. Department of Energy, and iOLAP. My focus is Embedded Systems but I have a strong passion for robotics, automation, machine learning, and artificial intelligence.</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Former Secretary -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/katie-lee.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#"> Katie Lee</a><span class="small text-silver-chalice">Former Secretary</span></h6>
-                                <p>I’m a transfer student from UH. I’m studying Computer Engineering because I want to be on the front of the newest technology development, and I’m the secretary for UNT Robotics.</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Former Event Coordinator -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/michelle-vargas.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#"> Michelle Rosal Vargas</a><span class="small text-silver-chalice">Former Event Coordinator</span></h6>
-                                <p>Mechanical Engineer | Event Coordinator at UNT Robotics</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Former Public Relations -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/andrew-jarrett.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#"> Andy Jarrett</a><span class="small text-silver-chalice">Former Public Relations</span></h6>
-                                <p>Mechanical Engineer | Public Relations at UNT Robotics</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Former Project Manager -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/nicole-kohm.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#">Nicole Kohm</a><span class="small text-silver-chalice">Former Project Manager</span></h6>
-                                <p>I am an adaptive problem-solver with a lifetime of scientific passion. I enjoy applying what I learn to make new ideas and possibilities come to fruition. I have a strong track record of careful attention to detail and thinking outside the box. I frequently invent new technologies and methods to quickly solve multidisciplinary problems.</p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Former Aerospace Division Lead -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/jesse-sullivan.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#"> Jesse Sullivan</a><span class="small text-silver-chalice">Former Aerospace Division Lead</span></h6>
-                                <p>Jesse is a senior mechanical engineering student interested in all things that fly and go fast. He has 4 years of experience in amateur high-power rocketry and currently holds an L1 certification with the National Association of Rocketry. He founded the Aerospace Division with UNT Robotics in order to foster interest in the hobby and provide a learning experience for anyone to become a part of. </p>
-                                <ul class="list-inline-lg">
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
+                <?php
+                foreach ($members as $member) {
+                    get_member_card($member['name'], $member['title'], $member['description'], $member['picture_uri'], $member['email']??null, $member['linkedin_url'] ?? null, $member['github_url'] ?? null, $member['twitter_url'] ?? null);
+                }
+                ?>
             </div>
         </section>
     </main>

--- a/about/our-team.php
+++ b/about/our-team.php
@@ -1,14 +1,149 @@
 <?php
 require('../template/top.php');
+require('../template/functions/card.php');
 head('Our Team', true);
+$members = array();
+
+//co-president
+$members[] = [
+        'name'=>'Sebastian King',
+        'title'=>'Co-President',
+        'description'=>"Sebastian is a post-baccalaureate world languages student, with a degree in Computer Science. His role is to oversee the day-to-day running of the organisation and help ensure the organisation best serves the students at UNT. His expertise are programming and electrical engineering and he specialises in networking and remote control systems. He is also responsible for a lot of the more ambitious projects around campus, including the famous Sofabot and our re-usable weather balloon project.",
+        'picture_uri'=>'/images/bio-pics/sebastian-king.jpg',
+        'email'=>'president@untrobotics.com',
+        'linkedin_url'=>'https://www.linkedin.com/in/sebastian-king',
+        'github_url'=>'https://www.github.com/sebastian-king',
+        'twitter_url'=>'https://www.twitter.com/@thekingseb'
+];
+//co-president2
+$members[] = [
+        'name'=>'Lauren Caves',
+        'title'=>'Co-President',
+        'description'=> "She’s a woman of action, eternal optimist, and a passionate speaker. As an undergraduate mechanical engineering student, her enthusiasm for the art of engineering is vast and the hunger for discovery drives her motivation which has led to many successes during her undergraduate years. Although not easily. She has gone through many failures and complicated situations which shaped a new passion to inspire the youth and other students to overcome diversity and really fight for their dreams. She believes everyone is destined for greatness, and that it's important to not let the minor roadblocks we stumble upon crush the stars we wish upon.",
+        'picture_uri'=>'/images/bio-pics/lauren-caves.jpg',
+        'email'=>'president@untrobotics.com',
+        'linkedin_url'=>'https://www.linkedin.com/in/lauren-caves',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+//vice president
+$members[] = [
+        'name'=>'Tyler Adam Martinez',
+        'title'=>'Vice President and Financial Director',
+        'description'=>'Tyler is a junior currently studying electrical engineering with a minor in biomedical engineering. He focuses on robotics and automation, and loves designing cool circuits and building electronics.',
+        'picture_uri'=>'/images/bio-pics/tyler-adam-martinez.jpg',
+        'email'=>'vice-president@untrobotics.com',
+        'linkedin_url'=>'https://www.linkedin.com/in/tyleradammartinez',
+        'github_url'=>'https://www.github.com/TylerAdamMartinez',
+    //    'twitter_url'=>''
+];
+// financial director
+//$officers[] = [
+//        'name'=>'Tyler Adam Martinez',
+//        'title'=>'Vice President and Financial Director',
+//        'description'=>'Tyler is a junior currently studying electrical engineering with a minor in biomedical engineering. He focuses on robotics and automation, and loves designing cool circuits and building electronics.',
+//        'picture_uri'=>'/images/bio-pics/tyler-adam-martinez.jpg',
+//        'email'=>'treasury@untrobotics.com',
+//        'linkedin_url'=>'https://www.linkedin.com/in/tyleradammartinez',
+//        'github_url'=>'https://www.github.com/TylerAdamMartinez',
+//    //    'twitter_url'=>''
+//];
+
+// deputy financial director
+$members[] = [
+    'name'=>'Andrew Paul',
+    'title'=>'Deputy Financial Director',
+    'description'=>'The Eagle Scout, Black Belt and Rescue scuba diver brings his vast experience keeping the funds up, and in check for the the future development of the robotics club. Andrew Paul is a freshman mechanical engineering student and lover of innovation. New to the scene with charisma to spare and a passion for engineering. He can be found climbing at the UNT Rockwall,  or in his dorm finding out new ways to build and code his next project while assisting in club finances.',
+    'picture_uri'=>'/images/bio-pics/andrew-paul.jpg',
+    'email'=>'deputy-financial-director@untrobotics.com',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+// Public Relations
+$members[] = [
+    'name'=>'Jacob Gomez',
+    'title'=>'Public Relations',
+    'description'=>'Jacob is a current Computer Science student at UNT.Although he balances school and work he finds time for extracurriculars.He has always enjoyed being apart of different organizations and getting to know new people. He loves using all the different software to model, create and design things for the club or for his own personal projects.',
+    'picture_uri'=>'/images/bio-pics/jacob-gomez.jpg',
+    'email'=>'public-relations@untrobotics.com',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+
+// Event Coordinator
+$members[] = [
+    'name'=>'Abdus Samee',
+    'title'=>'Event Coordinator',
+    'description'=>"Abdus Samee is an ECE graduate whose love for engineering must be seen to be believed. Being a former Toastmaster, he has a flair for speaking which convinces the listener to accept the facts that he puts forward. His never ending hunger for knowledge has enabled him to achieve a lot in a short time. Education is an ornament in prosperity and a refuge in adversity is what he says. Progress never comes without struggles, but his persistence helped him reach his dream destination. He is also the Vice Chair for UNT IEEE Robotics and Automation Society, and a IEEE Eta Kappa Nu Honor Student. The words of Ford inspired him to keep going. 'When everything seems to be going against you, remember that the airplane takes off against the wind and not with it.",
+    'picture_uri'=>'/images/bio-pics/abdus-samee.jpg',
+    'email'=>'event-coordinator@untrobotics.com',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+
+// Social Media Manager
+$members[] = [
+    'name'=>'Ally Flores',
+    'title'=>'Social Media Manager',
+    'description'=>"Ally is a freshman majoring in mechanical engineering technology. She’s been in robotics since high school and is excited to continue it through college. She loves trying new hobbies and making new friends!",
+    'picture_uri'=>'/images/bio-pics/ally-flores.jpg',
+    'email'=>'corp-relations@untrobotics.com',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+
+// (lead) Webmaster
+$members[] = [
+    'name'=>'Peyton Thibodeaux',
+    'title'=>'Webmaster',
+    'description'=>"Peyton is a junior, studying computer science with a minor in mathematics. He's the webmaster for UNT Robotics and in charge of the website that you see in front of you. He enjoys learning and using new technologies and have a passion for creating things.",
+    'picture_uri'=>'/images/bio-pics/peyton-thibodeaux.jpg',
+    'email'=>'webmaster@untrobotics.com',
+    'linkedin_url'=>'https://www.linkedin.com/in/peyton-thibodeaux',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+
+// Project Manager
+$members[] = [
+    'name'=>'Nicholas Tindle',
+    'title'=>'Project Manager',
+    'description'=>"Nicholas Tindle is a Computer Engineering student at UNT. He works in software engineering and loves hackathons. You can generally find him wearing a hat and probably a sweatshirt. He has a long history of collaboration with UNT Robotics as the first president, a loyal advisor, and now Project Manager. He has also served as an advisor to the Dean and is currently an officer of Engineering United. Nick has helped host numerous events at the university over the years. In his professional life, he works in data analysis, web development, and python scripting.",
+    'picture_uri'=>'/images/bio-pics/nick-tindle.jpg',
+    'email'=>'project-manager@untrobotics.com',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+
+// Corporate Relations
+$members[] = [
+    'name'=>'Ashank Annam',
+    'title'=>'Corporate Relations',
+    'description'=>"Ashank is a freshman studying Business Computer Information Systems. He has been interested in robotics since high school. He loves to meet new people and learn new technologies.",
+    'picture_uri'=>'/images/bio-pics/ashank-annam.jpg',
+    'email'=>'corp-relations@untrobotics.com',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
+
+// Joe
+$members[] = [
+    'name'=>'Joseph moore',
+    'title'=>'Aerospace Division Lead',
+    'description'=>"Joseph is a Junior Mechanical Engineering student. Formerly a US Marine Master Explosive Ordnance Disposal Technician (EOD), he has always tried to tinker with things and figure out how they work and is passionate about establishing and growing our High-Power Rocketry team into a nationally competitive force. Both through STEM outreach efforts and internal events, he hopes to generate interest and encourage everyone to get into hobby rocketry, and the sport of high power rocketry.",
+    'picture_uri'=>'/images/bio-pics/joe-moore.jpg',
+    'email'=>'aerospace@untrobotics.com',
+//    'linkedin_url'=>'',
+//    'github_url'=>'',
+//    'twitter_url'=>''
+];
 ?>
-    <style>
-        .bio-area {
-            border-top: 2px solid #ececec;
-            margin-top: 10px;
-            padding-top: 10px;
-        }
-    </style>
     <main class="page-content">
         <!-- Classic Breadcrumbs-->
         <section class="breadcrumb-classic">
@@ -34,252 +169,11 @@ head('Our Team', true);
                         <h6>These people are the reason for our success and expertise.</h6>
                     </div>
                 </div>
-                <!-- co-president -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/sebastian-king.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                <div class="cell-md-6">
-                    <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                        <h6 class="h6-with-small"><a href="#"> Sebastian King</a><span class="small text-silver-chalice">Co-President</span></h6>
-                        <p>Sebastian is a post-baccalaureate world languages student, with a degree in Computer Science. His role is to oversee the day-to-day running of the organisation and help ensure the organisation best serves the students at UNT. His expertise are programming and electrical engineering and he specialises in networking and remote control systems. He is also responsible for a lot of the more ambitious projects around campus, including the famous Sofabot and our re-usable weather balloon project. </p>
-                        <ul class="list-inline-lg">
-                            <li>
-                                <a href="mailto:president@untrobotics.com " class="icon icon-sm text-primary fa-envelope"></a>
-                            </li>
-                            <li>
-                                <a href="https://www.linkedin.com/in/sebastian-king" class="icon icon-sm text-primary fa-linkedin"></a>
-                            </li>
-                            <li>
-                                <a href="https://www.twitter.com/@thekingseb" class="icon icon-sm text-primary fa-twitter"></a>
-                            </li>
-                            <li>
-                                <a href="https://www.github.com/sebastian-king" class="icon icon-sm text-primary fa-github"></a>
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-            </div>
-            <!-- co-president -->
-            <div class="cell-lg-12 bio-area">
-                <div class="range range-sm-middle">
-                    <div class="cell-md-3"><img src="/images/bio-pics/lauren-caves.jpg" alt="" width="360" height="404" class="img-responsive" />
-                    </div>
-                    <div class="cell-md-6">
-                        <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                            <h6 class="h6-with-small"><p> Lauren Caves</p><span class="small text-silver-chalice">Co-President</span></h6>
-                            <p>She’s a woman of action, eternal optimist, and a passionate speaker. As an undergraduate mechanical engineering student, her enthusiasm for the art of engineering is vast and the hunger for discovery drives her motivation which has led to many successes during her undergraduate years. Although not easily. She has gone through many failures and complicated situations which shaped a new passion to inspire the youth and other students to overcome diversity and really fight for their dreams. She believes everyone is destined for greatness, and that it's important to not let the minor roadblocks we stumble upon crush the stars we wish upon. </p>
-                            <ul class="list-inline-lg">
-                                <li>
-                                    <a href="mailto:president@untrobotics.com " class="icon icon-sm text-primary fa-envelope"></a>
-                                </li>
-                                <li>
-                                    <a href="https://www.linkedin.com/in/lauren-caves" class="icon icon-sm text-primary fa-linkedin"></a>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <!-- Vice President and Financial Director -->
-            <div class="cell-lg-12 bio-area">
-                <div class="range range-sm-middle">
-                    <div class="cell-md-3"><img src="/images/bio-pics/tyler-adam-martinez.jpg" alt="" width="360" height="404" class="img-responsive" />
-                    </div>
-                    <div class="cell-md-6">
-                        <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                            <h6 class="h6-with-small"><p> Tyler Adam Martinez</p><span class="small text-silver-chalice">Vice President and Financial Director</span></h6>
-                            <p>Tyler is a junior currently studying electrical engineering with a minor in biomedical engineering. He focuses on robotics and automation, and loves designing cool circuits and building electronics. </p>
-                            <ul class="list-inline-lg">
-                                <li>
-                                    <a href="mailto:vice-president@untrobotics.com" class="icon icon-sm text-primary fa-envelope"></a>
-                                </li>
-                                <li>
-                                    <a href="https://www.linkedin.com/in/tyleradammartinez/" class="icon icon-sm text-primary fa-linkedin"></a>
-                                </li>
-                                <li>
-                                    <a href="https://github.com/TylerAdamMartinez" class="icon icon-sm text-primary fa-github"></a>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-                <!-- financial director -->
-<!--                <div class="cell-lg-12 bio-area">-->
-<!--                    <div class="range range-sm-middle">-->
-<!--                        <div class="cell-md-3"><img src="/images/bio-pics/tyler-adam-martinez.jpg" alt="" width="360" height="404" class="img-responsive" style = "-webkit-transform: scaleX(-1);-->
-<!--  transform: scaleX(-1);" />-->
-<!--                        </div>-->
-<!--                        <div class="cell-md-6">-->
-<!--                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">-->
-<!--                                <h6 class="h6-with-small"><a href="#"> Tyler Adam Martinez</a><span class="small text-silver-chalice">Financial Director</span></h6>-->
-<!--                                <p>Tyler is a junior currently studying electrical engineering with a minor in biomedical engineering. He focuses on robotics and automation, and loves designing cool circuits and building electronics. </p>-->
-<!--                                <ul class="list-inline-lg">-->
-<!--                                    <li>-->
-<!--                                        <a href="mailto:treasury@untrobotics.com" class="icon icon-sm text-primary fa-envelope"></a>-->
-<!--                                    </li>-->
-<!--                                    <li>-->
-<!--                                        <a href="https://www.linkedin.com/in/tyleradammartinez/" class="icon icon-sm text-primary fa-linkedin"></a>-->
-<!--                                    </li>-->
-<!--                                    <li>-->
-<!--                                        <a href="https://github.com/TylerAdamMartinez" class="icon icon-sm text-primary fa-github"></a>-->
-<!--                                    </li>-->
-<!--                                </ul>-->
-<!--                            </div>-->
-<!--                        </div>-->
-<!--                    </div>-->
-<!--                </div>-->
-                <!-- Deputy Financial Director -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/andrew-paul.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#">Andrew Paul</a><span class="small text-silver-chalice">Deputy Financial Director</span></h6>
-                                <p>The Eagle Scout, Black Belt and Rescue scuba diver brings his vast experience keeping the funds up, and in check for the the future development of the robotics club. Andrew Paul is a freshman mechanical engineering student and lover of innovation. New to the scene with charisma to spare and a passion for engineering. He can be found climbing at the UNT Rockwall,  or in his dorm finding out new ways to build and code his next project while assisting in club finances. </p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="mailto:deputy-financial-director@untrobotics.com" class="icon icon-sm text-primary fa-envelope"></a>
-                                    </li>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Public Relations -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/jacob-gomez.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#">Jacob Gomez</a><span class="small text-silver-chalice">Public Relations</span></h6>
-                                <p>Jacob is a current Computer Science student at UNT.Although he balances school and work he finds time for extracurriculars.He has always enjoyed being apart of different organizations and getting to know new people. He loves using all the different software to model, create and design things for the club or for his own personal projects. </p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="mailto:public-relations@untrobotics.com" class="icon icon-sm text-primary fa-envelope"></a>
-                                    </li>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Event coordinator -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/abdus-samee.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#"> Abdus Samee</a><span class="small text-silver-chalice">Event Coordinator</span></h6>
-                                <p>Abdus Samee is an ECE graduate whose love for engineering must be seen to be believed. Being a former Toastmaster, he has a flair for speaking which convinces the listener to accept the facts that he puts forward. His never ending hunger for knowledge has enabled him to achieve a lot in a short time. Education is an ornament in prosperity and a refuge in adversity is what he says. Progress never comes without struggles, but his persistence helped him reach his dream destination. He is also the Vice Chair for UNT IEEE Robotics and Automation Society, and a IEEE Eta Kappa Nu Honor Student. The words of Ford inspired him to keep going. 'When everything seems to be going against you, remember that the airplane takes off against the wind and not with it. </p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="mailto:event-coordinator@untrobotics.com" class="icon icon-sm text-primary fa-envelope"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Social Media Manager -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/ally-flores.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#">Ally Flores</a><span class="small text-silver-chalice">Social Media Manager</span></h6>
-                                <p>Ally is a freshman majoring in mechanical engineering technology. She’s been in robotics since high school and is excited to continue it through college. She loves trying new hobbies and making new friends! </p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="mailto:corp-relations@untrobotics.com" class="icon icon-sm text-primary fa-envelope"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Webmaster -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/peyton-thibodeaux.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#"> Peyton Thibodeaux</a><span class="small text-silver-chalice">Webmaster</span></h6>
-                                <p>Peyton is a junior, studying computer science with a minor in mathematics. He's the webmaster for UNT Robotics and in charge of the website that you see in front of you. He enjoys learning and using new technologies and have a passion for creating things. </p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="mailto:webmaster@untrobotics.com" class="icon icon-sm text-primary fa-envelope"></a>
-                                    </li>
-                                    <li>
-                                        <a href="https://www.linkedin.com/in/peyton-thibodeaux" class="icon icon-sm text-primary fa-linkedin"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Project Manager -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/nick-tindle.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#"> Nicholas Tindle</a><span class="small text-silver-chalice">Project Manager</span></h6>
-                                <p>Nicholas Tindle is a Computer Engineering student at UNT. He works in software engineering and loves hackathons. You can generally find him wearing a hat and probably a sweatshirt. He has a long history of collaboration with UNT Robotics as the first president, a loyal advisor, and now Project Manager. He has also served as an advisor to the Dean and is currently an officer of Engineering United. Nick has helped host numerous events at the university over the years. In his professional life, he works in data analysis, web development, and python scripting. </p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="mailto:project-manager@untrobotics.com " class="icon icon-sm text-primary fa-envelope"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Corporate Relations -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/ashank-annam.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#"> Ashank Annam</a><span class="small text-silver-chalice">Corporate Relations</span></h6>
-                                <p>Ashank is a freshman studying Business Computer Information Systems. He has been interested in robotics since high school. He loves to meet new people and learn new technologies. </p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="mailto:corp-relations@untrobotics.com" class="icon icon-sm text-primary fa-envelope"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Aerospace Division Lead -->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/joe-moore.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#"> Joe Moore</a><span class="small text-silver-chalice">Aerospace Division Lead</span></h6>
-                                <p>Joseph is a Junior Mechanical Engineering student. Formerly a US Marine Master Explosive Ordnance Disposal Technician (EOD), he has always tried to tinker with things and figure out how they work and is passionate about establishing and growing our High-Power Rocketry team into a nationally competitive force. Both through STEM outreach efforts and internal events, he hopes to generate interest and encourage everyone to get into hobby rocketry, and the sport of high power rocketry. </p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="mailto:aerospace@untrobotics.com " class="icon icon-sm text-primary fa-envelope"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+                <?php
+                foreach ($members as $member) {
+                    get_member_card($member['name'], $member['title'], $member['description'], $member['picture_uri'], $member['email']??null, $member['linkedin_url'] ?? null, $member['github_url'] ?? null, $member['twitter_url'] ?? null);
+                }
+                ?>
             </div>
         </section>
     </main>

--- a/about/our-web-team.php
+++ b/about/our-web-team.php
@@ -1,17 +1,111 @@
 <?php
 require('../template/top.php');
+require('../template/functions/card.php');
 head('Our Team', true);
+$members = array();
+$members[] = [
+    'name'=>'Peyton Thibodeaux',
+    'title'=>'Webmaster | Team Member',
+    'description'=>"Peyton is a junior, studying computer science with a minor in mathematics. He's the webmaster for UNT Robotics and in charge of the website that you see in front of you. He enjoys learning and using new technologies and have a passion for creating things.",
+    'picture_uri'=>'/images/web-team-pics/peyton-thibodeaux.jpg',
+    'email'=>'webmaster@untrobotics.com',
+    'linkedin_url'=>'https://www.linkedin.com/in/peyton-thibodeaux',
+    'github_url'=>'https://www.github.com/peyton232',
+//    'twitter_url'=>''
+];
+$members[] = [
+    'name'=>'Sebastian King',
+    'title'=>'Alumni | Team Member',
+    'description'=>"Sebastian is a post-baccalaureate world languages student, with a degree in Computer Science. His role is to oversee the day-to-day running of the organisation and help ensure the organisation best serves the students at UNT. His expertise are programming and electrical engineering and he specialises in networking and remote control systems. He is also responsible for a lot of the more ambitious projects around campus, including the famous Sofabot and our re-usable weather balloon project.",
+    'picture_uri'=>'/images/web-team-pics/sebastian-king.jpg',
+//    'email'=>'',
+    'linkedin_url'=>'https://www.linkedin.com/in/sebastian-king',
+    'github_url'=>'https://www.github.com/sebastian-king',
+//    'twitter_url'=>''
+];
+$members[] = [
+    'name'=>'Nicholas Tindle',
+    'title'=>'President | Team Member',
+    'description'=>"Nicholas Tindle is a Computer Engineering student at UNT. He works in software engineering and loves hackathons. You can generally find him wearing a hat and probably a sweatshirt. He has a long history of collaboration with UNT Robotics as the first president, a loyal advisor, and now Project Manager. He has also served as an advisor to the Dean and is currently an officer of Engineering United. Nick has helped host numerous events at the university over the years. In his professional life, he works in data analysis, web development, and python scripting.",
+    'picture_uri'=>'/images/web-team-pics/nick-tindle.jpg',
+//    'email'=>'',
+    'linkedin_url'=>'https://www.linkedin.com/in/ntindle',
+    'github_url'=>'https://www.github.com/ntindle',
+//    'twitter_url'=>''
+];
+$members[] = [
+    'name'=>'Henry Legay',
+    'title'=>'Team Member',
+    'description'=>"Henry Legay is a Computer Science Student at UNT focused on web development. He is a web developer in Robotics with ready applicable experience and a willingness to learn.",
+    'picture_uri'=>'/images/web-team-pics/henry-legay.jpg',
+//    'email'=>'',
+    'linkedin_url'=>'https://www.linkedin.com/in/henrylegay',
+    'github_url'=>'https://www.github.com/henlegay',
+//    'twitter_url'=>''
+];
+$members[] = [
+    'name'=>'Mason Besmer',
+    'title'=>'Team Member',
+    'description'=>"Mason Besmer is a Computer Science student at UNT. He is a webmaster for UNT Robotics and participates in many student orgs. He creates many things and comes up with ideas for even more. In his free time, he likes to create environments for games and program the website in front of you. He likes organization and loves to tinker with things. Creator of his own magic mirror, Mason is a advocate for building his own electronics. Currently, he is working on a software solution for his Starcube. You can find out more about it on his LinkedIn.",
+    'picture_uri'=>'/images/web-team-pics/mason-besmer.jpg',
+//    'email'=>'',
+    'linkedin_url'=>'https://www.linkedin.com/in/masonbesmer',
+    'github_url'=>'https://www.github.com/shotbyapony',
+//    'twitter_url'=>''
+];
+$members[] = [
+    'name'=>'Aryan Damle',
+    'title'=>'Team Member',
+    'description'=>"Aryan Damle is a Computer Science student at UNT. He is an aspiring full stack web developer and an avid Home Assistant enthusiast. He mentors a high school robotics team and loves to work on robots in his free time. You can find him at your local car meet on weekends if he isn't busy working on a robot or fixing something in his garage.",
+    'picture_uri'=>'/images/web-team-pics/aryan-damle.jpg',
+//    'email'=>'',
+    'linkedin_url'=>'https://www.linkedin.com/in/aryan-damle-8691b11bb',
+    'github_url'=>'https://www.github.com/aryan-damle',
+//    'twitter_url'=>''
+];
+$members[] = [
+    'name'=>'Mary Plana',
+    'title'=>'Team Member',
+    'description'=>"Mary Plana is a Computer Science Student at UNT with studies focused on Front End Development. She loves designing and implementing the user interface of a project. She has a natural curiosity about the world and loves to learn and improve her skills. She is currently the president of Application Development Organization. She facilitates the meeting and leads student UI designers to design, implement, and improve the user interface of projects.",
+    'picture_uri'=>'/images/web-team-pics/mary-plana.jpg',
+//    'email'=>'',
+    'linkedin_url'=>'https://www.linkedin.com/in/mary-plana',
+    'github_url'=>'https://www.github.com/mcp31',
+//    'twitter_url'=>''
+];
+$members[] = [
+    'name'=>'David Thompson',
+    'title'=>'Team Member',
+    'description'=>"David Thompson is a Computer Science Student at UNT with studies focused on Full Stack Development. He loves solving problems, learning new things, and is currently working with a start up on a social media application that is currently in Apple's TestFlight.",
+    'picture_uri'=>'/images/web-team-pics/david-thompson.jpg',
+//    'email'=>'',
+    'linkedin_url'=>'https://www.linkedin.com/in/david-thompson-000',
+    'github_url'=>'https://www.github.com/davidkt99',
+//    'twitter_url'=>''
+];
+
+$members[] = [
+    'name'=>'Samin Yasar',
+    'title'=>'Team Member',
+    'description'=>"Samin Yasar is a senior Computer Science student at UNT. He is a team member of UNT Robotics webmaster helping maintain UNT Robotics website. He is also a part of the Application Development Organization as a team member. He likes to learn new things and solve complex problems.",
+    'picture_uri'=>'/images/web-team-pics/samin-yasar.jpg',
+//    'email'=>'',
+    'linkedin_url'=>'https://www.linkedin.com/in/samin2668',
+    'github_url'=>'https://www.github.com/samin2668',
+//    'twitter_url'=>''
+];
+
+$members[] = [
+    'name'=>'Kenneth Chen',
+    'title'=>'Team Member',
+    'description'=>"Kenneth Chen is a Computer Science and Accounting student at UNT. As part of UNT Robotics, he's programmed helpful things, such as the controller connections for Botathon Season 3. He is also the financial director of UNT Robotics. He enjoys learnings and helping others and hopes to make the website more accessible.",
+    'picture_uri'=>'/images/bio-pics/kenneth-chen.jpg',
+//    'email'=>'',
+    'linkedin_url'=>'https://www.linkedin.com/in/kenneth-w-chen',
+    'github_url'=>'https://www.github.com/kenneth-w-chen',
+//    'twitter_url'=>''
+];
 ?>
-    <style>
-        .bio-area {
-            border-top: 2px solid #ececec;
-            margin-top: 10px;
-            padding-top: 10px;
-        }
-        .bio-anchor {
-            position: absolute;
-        }
-    </style>
     <main class="page-content">
         <!-- Classic Breadcrumbs-->
         <section class="breadcrumb-classic">
@@ -36,274 +130,11 @@ head('Our Team', true);
                         <h6>These are the people who keep this site running.</h6>
                     </div>
                 </div>
-                <!-- Peyton Thibodeaux -->
-                <div class="cell-lg-12 bio-area">
-                    <div id="peyton-thibodeaux" class="bio-anchor"></div>
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/peyton-thibodeaux.jpg" alt="" width="360"
-                                                    height="404" class="img-responsive"/>
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#peyton-thibodeaux"> Peyton Thibodeaux</a><span class="small text-silver-chalice">Webmaster | Team Member</span></h6>
-                                <p>Peyton is a junior, studying computer science with a minor in mathematics. He's the webmaster for UNT Robotics and in charge of the website that you see in front of you. He enjoys learning and using new technologies and have a passion for creating things. </p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="https://www.linkedin.com/in/peyton-thibodeaux"
-                                           class="icon icon-sm text-primary fa-linkedin"></a>
-                                    </li>
-                                    <li>
-                                        <a href="https://www.github.com/peyton232"
-                                           class="icon icon-sm text-primary fa-github"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Sebastian King -->
-                <div class="cell-lg-12 bio-area">
-                    <div id="sebastian-king" class="bio-anchor"></div>
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/sebastian-king.jpg" alt="" width="360"
-                                                    height="404" class="img-responsive"/>
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 id="sebastian-king" class="h6-with-small"><a href="#sebastian-king"> Sebastian King</a><span class="small text-silver-chalice">Alumni | Team Member</span></h6>
-                                <p>Sebastian is a post-baccalaureate world languages student, with a degree in Computer Science. His role is to oversee the day-to-day running of the organisation and help ensure the organisation best serves the students at UNT. His expertise are programming and electrical engineering and he specialises in networking and remote control systems. He is also responsible for a lot of the more ambitious projects around campus, including the famous Sofabot and our re-usable weather balloon project. </p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="https://www.linkedin.com/in/sebastian-king"
-                                           class="icon icon-sm text-primary fa-linkedin"></a>
-                                    </li>
-                                    <li>
-                                        <a href="https://www.github.com/sebastian-king"
-                                           class="icon icon-sm text-primary fa-github"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Nick Tindle -->
-                <div class="cell-lg-12 bio-area">
-                    <div id="nicholas-tindle" class="bio-anchor"></div>
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/nick-tindle.jpg" alt="" width="360"
-                                                    height="404" class="img-responsive"/>
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 id="nicholas-tindle" class="h6-with-small"><a href="#nicholas-tindle"> Nicholas Tindle</a><span class="small text-silver-chalice">President | Team Member</span></h6>
-                                <p>Nicholas Tindle is a Computer Engineering student at UNT. He works in software engineering and loves hackathons. You can generally find him wearing a hat and probably a sweatshirt. He has a long history of collaboration with UNT Robotics as the first president, a loyal advisor, and now Project Manager. He has also served as an advisor to the Dean and is currently an officer of Engineering United. Nick has helped host numerous events at the university over the years. In his professional life, he works in data analysis, web development, and python scripting. </p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="https://www.linkedin.com/in/ntindle"
-                                           class="icon icon-sm text-primary fa-linkedin"></a>
-                                    </li>
-                                    <li>
-                                        <a href="https://github.com/ntindle"
-                                           class="icon icon-sm text-primary fa-github"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!--Henry Legay-->
-                <div class="cell-lg-12 bio-area">
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/web-team-pics/henry-legay.jpg" alt="" width="360"
-                                                    height="404" class="img-responsive"/>
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 id="henry-legay" class="h6-with-small"><a href="#henry-legay">Henry Legay</a>
-                                            <span class="small text-silver-chalice">Team Member</span></h6>
-                                <p> Henry Legay is a Computer Science Student at UNT focused on web development. He is a
-                                    web developer in Robotics with ready applicable experience and a willingness to
-                                    learn.</p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="https://www.linkedin.com/in/henrylegay/"
-                                           class="icon icon-sm text-primary fa-linkedin"></a>
-                                    </li>
-                                    <li>
-                                        <a href="https://github.com/henlegay" class="icon icon-sm text-primary fa-github"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Mason Besmer -->
-                <div class="cell-lg-12 bio-area">
-                    <div id="mason-besmer" class="bio-anchor"></div>
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/web-team-pics/mason-besmer.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 id="mason-besmer" class="h6-with-small"><a href="#mason-besmer"> Mason Besmer</a><span class="small text-silver-chalice">Team Member</span></h6>
-                                <p>Mason Besmer is a Computer Science student at UNT. He is a webmaster for UNT Robotics and participates in many student orgs. He creates many things and comes up with ideas for even more. In his free time, he likes to create environments for games and program the website in front of you. He likes organization and loves to tinker with things. Creator of his own magic mirror, Mason is a advocate for building his own electronics. Currently, he is working on a software solution for his Starcube. You can find out more about it on his LinkedIn.</p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="https://www.linkedin.com/in/masonbesmer" class="icon icon-sm text-primary fa-linkedin"></a>
-                                    </li>
-                                    <li>
-                                        <a href="https://www.github.com/shotbyapony" class="icon icon-sm text-primary fa-github"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Aryan Damle -->
-                <div class="cell-lg-12 bio-area">
-                    <div id="aryan-damle" class="bio-anchor"></div>
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/web-team-pics/aryan-damle.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#aryan-damle"> Aryan Damle</a><span class="small text-silver-chalice">Team Member</span></h6>
-                                <p>Aryan Damle is a Computer Science student at UNT. He is an aspiring full stack web developer and an avid Home Assistant enthusiast. He mentors a high school robotics team and loves to work on robots in his free time. You can find him at your local car meet on weekends if he isn't busy working on a robot or fixing something in his garage.</p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="https://www.linkedin.com/in/aryan-damle-8691b11bb/" class="icon icon-sm text-primary fa-linkedin"></a>
-                                    </li>
-                                    <li>
-                                        <a href="https://github.com/aryan-damle" class="icon icon-sm text-primary fa-github"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Mary Plana -->
-                <div class="cell-lg-12 bio-area">
-                    <div id="mary-plana" class="bio-anchor"></div>
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/web-team-pics/mary-plana.jpg" alt="" width="360" height="404" class="img-responsive"/>
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#mary-plana">Mary Plana</a><span class="small text-silver-chalice">Team Member</span></h6>
-                                <p>Mary Plana is a Computer Science Student at UNT with studies focused on Front End Development. She loves designing and implementing the user interface of a project. She has a natural curiosity about the world
-                                    and loves to learn and improve her skills. She is currently the president of Application Development Organization. She facilitates the meeting and leads student UI
-                                    designers to design, implement, and improve the user interface of projects.</p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="https://www.linkedin.com/in/mary-plana/" class="icon icon-sm text-primary fa-linkedin"></a>
-                                    </li>
-                                    <li>
-                                        <a href="https://github.com/mcp31" class="icon icon-sm text-primary fa-github"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- David Thompson -->
-                <div class="cell-lg-12 bio-area">
-                    <div id="david-thompson" class="bio-anchor"></div>
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/web-team-pics/david-thompson.jpg" alt="" width="360" height="404" class="img-responsive"/>
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#david-thompson">David Thompson</a><span class="small text-silver-chalice">Team Member</span></h6>
-                                <p>David Thompson is a Computer Science Student at UNT with studies focused on Full Stack Development. He loves solving problems, learning new things, and is currently working with a start up on a social media
-                                application that is currently in Apple's TestFlight.</p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="https://www.linkedin.com/in/david-thompson-000/" class="icon icon-sm text-primary fa-linkedin"></a>
-                                    </li>
-                                    <li>
-                                        <a href="https://github.com/davidkt99" class="icon icon-sm text-primary fa-github"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Samin Yasar -->
-                <div class="cell-lg-12 bio-area">
-                    <div id="samin-yasar" class="bio-anchor"></div>
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/web-team-pics/samin-yasar.jpg" alt="" width="360" height="404" class="img-responsive" />
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 class="h6-with-small"><a href="#samin-yasar"> Samin Yasar</a><span class="small text-silver-chalice">Team Member</span></h6>
-                                <p>Samin Yasar is a senior Computer Science student at UNT. He is a team member of UNT Robotics webmaster helping maintain UNT Robotics website. He is also a part of the Application Development Organization as a team member. He likes to learn new things and solve complex problems.</p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="https://www.linkedin.com/in/samin2668" class="icon icon-sm text-primary fa-linkedin"></a>
-                                    </li>
-                                    <li>
-                                        <a href="https://www.github.com/samin2668" class="icon icon-sm text-primary fa-github"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Kenneth Chen -->
-                <div class="cell-lg-12 bio-area">
-                    <div id="kenneth-chen" class="bio-anchor"></div>
-                    <div class="range range-sm-middle">
-                        <div class="cell-md-3"><img src="/images/bio-pics/kenneth-chen.jpg" alt="" width="360"
-                                                    height="404" class="img-responsive"/>
-                        </div>
-                        <div class="cell-md-6">
-                            <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">
-                                <h6 id="kenneth-chen" class="h6-with-small"><a href="#kenneth-chen"> Kenneth Chen</a><span class="small text-silver-chalice">Team Member</span></h6>
-                                <p>Kenneth Chen is a Computer Science and Accounting student at UNT.
-                                    As part of UNT Robotics, he's programmed helpful things, such as the controller
-                                    connections for Botathon Season 3. He is also the financial director of UNT
-                                    Robotics. He enjoys learnings and helping others and hopes to make the website more accessible. </p>
-                                <ul class="list-inline-lg">
-                                    <li>
-                                        <a href="https://www.linkedin.com/in/kenwc"
-                                           class="icon icon-sm text-primary fa-linkedin"></a>
-                                    </li>
-                                    <li>
-                                        <a href="https://www.github.com/chenneth"
-                                           class="icon icon-sm text-primary fa-github"></a>
-                                    </li>
-                                </ul>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <!-- Template NOTE: images must be 360 by 404 px, and take up less than -->
-                <!--            <div class="cell-lg-12 bio-area">-->
-                <!--            <div id="first-last" class="bio-anchor"></div> -->
-                <!--                <div class="range range-sm-middle">-->
-                <!--                    <div class="cell-md-3"><img src="/images/bio-pics/fileName.jpg" alt="" width="360" height="404" class="img-responsive" />-->
-                <!--                    </div>-->
-                <!--                    <div class="cell-md-6">-->
-                <!--                        <div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">-->
-                <!--                            <h6 id="Your-Name" class="h6-with-small"><a href="#first-last"> FirstName LastName</a><span class="small text-silver-chalice">Team Member</span></h6>-->
-                <!--                            <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>-->
-                <!--                            <ul class="list-inline-lg">-->
-                <!--                                <li>-->
-                <!--                                    <a href="https://www.linkedin.com/in/yourLinkedin" class="icon icon-sm text-primary fa-linkedin"></a>-->
-                <!--                                </li>-->
-                <!--                                <li>-->
-                <!--                                    <a href="https://www.github.com/yourGithub" class="icon icon-sm text-primary fa-github"></a>-->
-                <!--                                </li>-->
-                <!--                            </ul>-->
-                <!--                        </div>-->
-                <!--                    </div>-->
-                <!--                </div>-->
-                <!--            </div>-->
+                <?php
+                foreach ($members as $member) {
+                    get_member_card($member['name'], $member['title'], $member['description'], $member['picture_uri'], $member['email']??null, $member['linkedin_url'] ?? null, $member['github_url'] ?? null, $member['twitter_url'] ?? null);
+                }
+                ?>
             </div>
         </section>
     </main>

--- a/css/style.css
+++ b/css/style.css
@@ -48055,3 +48055,10 @@ header nav.rd-navbar-static.rd-navbar-secondary .rd-navbar-nav > li.thin {
   margin: 0 auto;
 }
 /*# sourceMappingURL=style.css.map */
+
+/*Adds a line above the bios in about/our-team, about/our-dev-team, and about/our-alumni*/
+.bio-area {
+  border-top: 2px solid #ececec;
+  margin-top: 10px;
+  padding-top: 10px;
+}

--- a/template/functions/card.php
+++ b/template/functions/card.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * @param string $name First and last name of individual
+ * @param string $title Their position or title in the org
+ * @param string $description The description paragraph about the individual
+ * @param string $picture_uri The URI of the individual's headshot
+ * @param string|null $email The position's contact email. E.g., president@untrobotics.com
+ * @param string|null $linkedin_url
+ * @param string|null $github_url
+ * @param string|null $twitter_url
+ * @return void
+ */
+function get_member_card(string $name, string $title, string $description, string $picture_uri, ?string $email = null, ?string $linkedin_url = null, ?string $github_url = null, ?string $twitter_url = null){
+
+    $contact_links_html = '';
+    if($email !== null){
+        $contact_links_html .= '<li>' .
+                                    "<a href='mailto:{$email}' class='icon icon-sm text-primary fa-envelope'></a>" .
+                                '</li>';
+    }
+    if($linkedin_url !== null){
+        $contact_links_html .= '<li>' .
+            "<a href='{$linkedin_url}' class='icon icon-sm text-primary fa-linkedin'></a>" .
+        '</li>';
+    }
+    if($github_url !== null){
+        $contact_links_html .=  '<li>' .
+                                        "<a href='{$github_url}' class='icon icon-sm text-primary fa-github'></a>" .
+                                '</li>';
+    }
+    if($twitter_url !== null){
+        $contact_links_html .=  '<li>' .
+            "<a href='{$twitter_url}' class='icon icon-sm text-primary fa-twitter'></a>" .
+            '</li>';
+    }
+
+    echo '<div class="cell-lg-12 bio-area">' .
+            '<div class="range range-sm-middle">' .
+                '<div class="cell-md-3">' .
+                    "<img src='{$picture_uri}' alt='' width='360' height='404' class='img-responsive' />" .
+                '</div>' .
+                '<div class="cell-md-6">' .
+                    '<div class="inset-xl-right-70 inset-xl-left-70 inset-left-15 inset-right-15">' .
+                        "<h6 class='h6-with-small'><p>{$name}</p><span class='small text-silver-chalice'>{$title}</span></h6>" .
+                        "<p>{$description}</p>" .
+                        '<ul class="list-inline-lg">' .
+                            $contact_links_html .
+                        '</ul>' .
+                    '</div>' .
+                '</div>' .
+            '</div>' .
+        '</div>';
+}


### PR DESCRIPTION
This PR is to componentize the `/about/our-team`, `/about/our-dev-team`, and `/about/our-alumni` pages in order to make it easier to add/remove members from these pages. Before, you had to dig through the HTML to find specific info about the member. Now, this info is quickly identifiable in an array at the top.

The CSS for `.bio-area` has been moved to `style.css` since it's used in these 3 pages.

This PR also removes the anchors from the `/about/our-dev-team` page because it wasn't consistent with the other pages (`our-alumni` did not have any, and `our-team` had empty anchors).

Also, I removed the template comment at the bottom of the dev team page, since it won't be needed to add new devs to the site.

Besides the above changes, none of the page contents or designs have been changed.

# tl;dr
* Page layout/design is the same
* Repeated HTML is now outputted through PHP and foreach loops
* Moved repeated CSS to our stylesheet