### PR TITLE
URW-205 Fix Discord bot not sending multiple attachments

### DIFF
--- a/api/discord/bot.php
+++ b/api/discord/bot.php
@@ -63,16 +63,14 @@ class DiscordBot {
 
 		// Add files to array
 		$files = array();
-        /** @noinspection PhpArrayUsedOnlyForWriteInspection */
         $tmp_files = [];    // needed if more than 1 attachment to prevent gc for deleting the temp files
 		if ($attachments) {
 			foreach ($attachments as $k => $attachment) {
 				if(isset($attachment['bin']))	// Function caller passed the raw data to the arg
 				{
 					// Since we have the data, we need to create a tmpfile to store that data for the CURLFile
-					$file = tmpfile();
-                    $tmp_files[] = $file;
-					$path = stream_get_meta_data($file)['uri'];
+					$tmp_files[$k] = tmpfile();
+					$path = stream_get_meta_data($tmp_files[$k])['uri'];
 					file_put_contents($path,$attachment['bin']);
 					$file_type = $attachment['type'];
 					$file_mime = ext2mime($file_type);
@@ -86,9 +84,8 @@ class DiscordBot {
 				else	// We assume the attachment is an online file that we need to download
 				{	// sebastian only insane people put curly braces on the same line
 					//$content = file_get_contents($attachment['url']);
-					$file = tmpfile();
-                    $tmp_files[] = $file;
-					$path = stream_get_meta_data($file)['uri'];
+                    $tmp_files[$k] = tmpfile();
+                    $path = stream_get_meta_data($tmp_files[$k])['uri'];
 					$ch = curl_init();
 					curl_setopt($ch, CURLOPT_URL, $attachment['url']);
 					curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);

--- a/api/discord/bot.php
+++ b/api/discord/bot.php
@@ -5,7 +5,7 @@ class DiscordBot {
 
 	protected static function send_api_request($URI, $method = 'GET', $content_type = "application/json", $data = null, $files = null) {
 		$ch = curl_init();
-		
+
 		$headers = array();
 		$headers[] = 'Authorization: Bot ' . static::AUTH_TOKEN;
 		$headers[] = 'Content-Type: ' . $content_type; //multipart/form-data';
@@ -41,18 +41,18 @@ class DiscordBot {
 		if (curl_errno($ch)) {
 			throw new DiscordBotException("Error occurred when making API request: '" . curl_error($ch) . "'" . "(" . curl_errno($ch) . ")");
 		}
-		
+
 		$status_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-		
+
 		curl_close($ch);
-		
+
 		$response = new stdClass();
 		$response->result = json_decode($result);
 		$response->status_code = $status_code;
 
 		return $response;
 	}
-	
+
 	public static function send_message($message, $channel_id, $attachments = null) {
 	    if (is_string($message)) {
             $data = new stdClass(); // can't be bothered right now to make a class
@@ -63,12 +63,15 @@ class DiscordBot {
 
 		// Add files to array
 		$files = array();
+        /** @noinspection PhpArrayUsedOnlyForWriteInspection */
+        $tmp_files = [];    // needed if more than 1 attachment to prevent gc for deleting the temp files
 		if ($attachments) {
 			foreach ($attachments as $k => $attachment) {
 				if(isset($attachment['bin']))	// Function caller passed the raw data to the arg
 				{
 					// Since we have the data, we need to create a tmpfile to store that data for the CURLFile
 					$file = tmpfile();
+                    $tmp_files[] = $file;
 					$path = stream_get_meta_data($file)['uri'];
 					file_put_contents($path,$attachment['bin']);
 					$file_type = $attachment['type'];
@@ -84,6 +87,7 @@ class DiscordBot {
 				{	// sebastian only insane people put curly braces on the same line
 					//$content = file_get_contents($attachment['url']);
 					$file = tmpfile();
+                    $tmp_files[] = $file;
 					$path = stream_get_meta_data($file)['uri'];
 					$ch = curl_init();
 					curl_setopt($ch, CURLOPT_URL, $attachment['url']);
@@ -108,18 +112,18 @@ class DiscordBot {
 			}
 		}
 		//error_log(var_export($files, true));
-		
+
 		return static::send_api_request("/channels/{$channel_id}/messages", 'POST', 'multipart/form-data', $data, $files);
 	}
-	
+
 	public static function add_user_role($guild_id, $user_id, $role_id) {
 		return static::send_api_request("/guilds/{$guild_id}/members/{$user_id}/roles/{$role_id}", 'PUT');
 	}
-	
+
 	public static function remove_user_role($guild_id, $user_id, $role_id) {
 		return static::send_api_request("/guilds/{$guild_id}/members/{$user_id}/roles/{$role_id}", 'DELETE');
 	}
-	
+
 	public static function type($channel_id) {
 		return static::send_api_request("/channels/{$channel_id}/typing", 'POST');
 	}
@@ -133,7 +137,7 @@ class DiscordBot {
         return $result->status_code == 429;
     }
 }
-								
+
 class DiscordBotException extends Exception {
 	public function __construct($message, $code = 0, Exception $previous = null) {
 		parent::__construct($message, $code, $previous);


### PR DESCRIPTION
The temp file handles were getting closed because no references to the handle were left after adding an additional attachment. This fixes it by storing the handles in an array.