### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/api/sendgrid/CONTRIBUTING.md
+++ b/api/sendgrid/CONTRIBUTING.md
@@ -125,7 +125,7 @@ Generally, we follow the style guidelines as suggested by the official language.
 
 Please run your code through:
 
-- [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer)
+- [PHP Code Sniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer)
 
 ## Creating a Pull Request
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932